### PR TITLE
Fix broken background transition in Cover Ambience

### DIFF
--- a/CoverAmbience/CoverAmbience.js
+++ b/CoverAmbience/CoverAmbience.js
@@ -1,12 +1,19 @@
 let ca_style = document.createElement('style');
 ca_style.innerHTML = `
 .main-nowPlayingBar-container {
-    background: linear-gradient(to right, var(--cover-color) 0, rgba(0,0,0,0) 280px, rgba(0,0,0,0) 100%);
+    position: relative;
 }
-.Root__now-playing-bar {
-    background-color: var(--spice-player);
+.main-nowPlayingBar-container::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+    background-color: var(--cover-color);
+    -webkit-mask-image: linear-gradient(to right, #000f 0, #0000 280px, #0000 100%);
 }
-.main-nowPlayingBar-container {
+.main-nowPlayingBar-container::before {
     transition: background 0.5s ease;
 }
 `;


### PR DESCRIPTION
Fixes the lack of a background animation by using a pesudo-element with a gradient mask. This gives the same result as before, but lets the background be animated again by setting it as a solid color.

https://user-images.githubusercontent.com/55464333/222860842-432a83fa-aea0-4188-bd38-581d4d05a491.mp4

