### PR TITLE
Update on all Queue headers

### DIFF
--- a/QueueTime/QueueTime.js
+++ b/QueueTime/QueueTime.js
@@ -26,5 +26,5 @@ document.head.appendChild( momentScript );
 
 setInterval( () => {
 	const totalTime = Spicetify.Queue?.nextTracks.reduce( ( acc, cur ) => acc + ( Number( cur.contextTrack.metadata.duration ) || 0 ), 0 );
-	document.querySelectorAll( ".queue-queuePage-header" )?.forEach(e => e.style.setProperty( '--queue-remaining', `'${moment.utc( totalTime + Spicetify.Player.getDuration() - Spicetify.Player.getProgress() ).format( 'HH:mm:ss' )} Remaining'` ) );
+	document.querySelectorAll( '.queue-queuePage-header' )?.forEach(e => e.style.setProperty( '--queue-remaining', `'${moment.utc( totalTime + Spicetify.Player.getDuration() - Spicetify.Player.getProgress() ).format( 'HH:mm:ss' )} Remaining'` ) );
 }, 1000 );

--- a/QueueTime/QueueTime.js
+++ b/QueueTime/QueueTime.js
@@ -24,11 +24,7 @@ momentScript.setAttribute( 'crossorigin', 'anonymous' );
 momentScript.setAttribute( 'referrerpolicy', 'no-referrer' );
 document.head.appendChild( momentScript );
 
-setInterval( function () {
-    let totalTime = 0;
-    Spicetify.Queue?.nextTracks.some( t => {
-        if ( isNaN( Number( t.contextTrack.metadata.duration ) ) ) return true;
-        totalTime += Number( t.contextTrack.metadata.duration );
-    } );
-	document.querySelector( `.queue-queuePage-header` )?.style.setProperty( '--queue-remaining', `'${moment.utc( totalTime + Spicetify.Player.getDuration() - Spicetify.Player.getProgress() ).format( 'HH:mm:ss' )} Remaining'` );
+setInterval( () => {
+	const totalTime = Spicetify.Queue?.nextTracks.reduce( ( acc, cur ) => acc + ( Number( cur.contextTrack.metadata.duration ) || 0 ), 0 );
+	document.querySelectorAll( ".queue-queuePage-header" )?.forEach(e => e.style.setProperty( '--queue-remaining', `'${moment.utc( totalTime + Spicetify.Player.getDuration() - Spicetify.Player.getProgress() ).format( 'HH:mm:ss' )} Remaining'` ) );
 }, 1000 );

--- a/QueueTime/QueueTime.js
+++ b/QueueTime/QueueTime.js
@@ -25,6 +25,6 @@ momentScript.setAttribute( 'referrerpolicy', 'no-referrer' );
 document.head.appendChild( momentScript );
 
 setInterval( () => {
-	const totalTime = Spicetify.Queue?.nextTracks.reduce( ( acc, cur ) => acc + ( Number( cur.contextTrack.metadata.duration ) || 0 ), 0 );
+	const totalTime = Spicetify.Queue?.nextTracks.reduce( ( acc, cur ) => acc + ( Number( cur.contextTrack.metadata.duration ) || 0 ), 0 ) || 0;
 	document.querySelectorAll( '.queue-queuePage-header' )?.forEach(e => e.style.setProperty( '--queue-remaining', `'${moment.utc( totalTime + Spicetify.Player.getDuration() - Spicetify.Player.getProgress() ).format( 'HH:mm:ss' )} Remaining'` ) );
 }, 1000 );


### PR DESCRIPTION
Apparently if you open the queue page while the panel is open it would only update one of them while the other freezes lol, since `querySelector` only returns one value.
This should do the trick. I also refactored it a bit to make the code more compact, hope you don't mind 😅.
![Spotify_o9V7oFti6b](https://github.com/kyrie25/theblockbuster-spicetify-extensions/assets/77577746/9163f6a0-a4a1-44b1-b587-8964fb875fa4)
