### PR TITLE
Break on delimiter

### DIFF
--- a/QueueTime/QueueTime.js
+++ b/QueueTime/QueueTime.js
@@ -27,7 +27,7 @@ document.head.appendChild( momentScript );
 setInterval( () => {
 	const totalTime = Spicetify.Queue?.nextTracks.slice( 0 ).reduce( ( acc, cur, _, arr ) => {
 		if ( isNaN( Number( cur.contextTrack.metadata.duration ) ) ) arr.splice(1);
-        	return acc + ( Number( cur.contextTrack.metadata.duration ) || 0 )
-    	}, 0 ) || 0;
+		return acc + ( Number( cur.contextTrack.metadata.duration ) || 0 )
+	}, 0 ) || 0;
 	document.querySelectorAll( '.queue-queuePage-header' )?.forEach(e => e.style.setProperty( '--queue-remaining', `'${moment.utc( totalTime + Spicetify.Player.getDuration() - Spicetify.Player.getProgress() ).format( 'HH:mm:ss' )} Remaining'` ) );
 }, 1000 );

--- a/QueueTime/QueueTime.js
+++ b/QueueTime/QueueTime.js
@@ -25,6 +25,9 @@ momentScript.setAttribute( 'referrerpolicy', 'no-referrer' );
 document.head.appendChild( momentScript );
 
 setInterval( () => {
-	const totalTime = Spicetify.Queue?.nextTracks.reduce( ( acc, cur ) => acc + ( Number( cur.contextTrack.metadata.duration ) || 0 ), 0 ) || 0;
+	const totalTime = Spicetify.Queue?.nextTracks.slice( 0 ).reduce( ( acc, cur, _, arr ) => {
+		if ( isNaN( Number( cur.contextTrack.metadata.duration ) ) ) arr.splice(1);
+        	return acc + ( Number( cur.contextTrack.metadata.duration ) || 0 )
+    	}, 0 ) || 0;
 	document.querySelectorAll( '.queue-queuePage-header' )?.forEach(e => e.style.setProperty( '--queue-remaining', `'${moment.utc( totalTime + Spicetify.Player.getDuration() - Spicetify.Player.getProgress() ).format( 'HH:mm:ss' )} Remaining'` ) );
 }, 1000 );


### PR DESCRIPTION
My apologies, apparently the previous commit I made didn't account for the loop break that the original `some` callback had when reaching the delimiter, which returns an incorrect queue time if the queue doesn't have enough songs and autoplay is on.
This commit should fix the issue 😅.