### PR TITLE
fix: rename Spicetify.Player.data.track -> Spicetify.Player.data.item

### DIFF
--- a/CoverAmbience/CoverAmbience.js
+++ b/CoverAmbience/CoverAmbience.js
@@ -111,7 +111,7 @@ function RGBToHSL(rgb) {
 }
 
 async function fetchExtractedColors() {
-    const res = await fetch(`https://api-partner.spotify.com/pathfinder/v1/query?operationName=fetchExtractedColors&variables=${encodeURIComponent(JSON.stringify({ uris: [Spicetify.Player.data.track.metadata.image_url] }))}&extensions=${encodeURIComponent(JSON.stringify({"persistedQuery":{"version":1,"sha256Hash":"d7696dd106f3c84a1f3ca37225a1de292e66a2d5aced37a66632585eeb3bbbfa"}}))}`, {
+    const res = await fetch(`https://api-partner.spotify.com/pathfinder/v1/query?operationName=fetchExtractedColors&variables=${encodeURIComponent(JSON.stringify({ uris: [Spicetify.Player.data.item.metadata.image_url] }))}&extensions=${encodeURIComponent(JSON.stringify({"persistedQuery":{"version":1,"sha256Hash":"d7696dd106f3c84a1f3ca37225a1de292e66a2d5aced37a66632585eeb3bbbfa"}}))}`, {
         method: "GET",
         headers: {
             authorization: `Bearer ${(await Spicetify.Platform.AuthorizationAPI._tokenProvider()).accessToken}`


### PR DESCRIPTION
Fixes a breaking change in [spicetify 2.28.0](https://github.com/spicetify/spicetify-cli/releases/tag/v2.28.0), which breaks Cover Ambiance