### PR TITLE
Fix CoverAmbience Auth

### DIFF
--- a/CoverAmbience/CoverAmbience.js
+++ b/CoverAmbience/CoverAmbience.js
@@ -114,7 +114,7 @@ async function fetchExtractedColors() {
     const res = await fetch(`https://api-partner.spotify.com/pathfinder/v1/query?operationName=fetchExtractedColors&variables=${encodeURIComponent(JSON.stringify({ uris: [Spicetify.Player.data.item.metadata.image_url] }))}&extensions=${encodeURIComponent(JSON.stringify({"persistedQuery":{"version":1,"sha256Hash":"d7696dd106f3c84a1f3ca37225a1de292e66a2d5aced37a66632585eeb3bbbfa"}}))}`, {
         method: "GET",
         headers: {
-            authorization: `Bearer ${(await Spicetify.Platform.AuthorizationAPI._tokenProvider()).accessToken}`
+            authorization: `Bearer ${Spicetify.Session.accessToken}`
         }
     })
     .then(res => res.json());

--- a/CoverAmbience/CoverAmbience.js
+++ b/CoverAmbience/CoverAmbience.js
@@ -114,7 +114,7 @@ async function fetchExtractedColors() {
     const res = await fetch(`https://api-partner.spotify.com/pathfinder/v1/query?operationName=fetchExtractedColors&variables=${encodeURIComponent(JSON.stringify({ uris: [Spicetify.Player.data.item.metadata.image_url] }))}&extensions=${encodeURIComponent(JSON.stringify({"persistedQuery":{"version":1,"sha256Hash":"d7696dd106f3c84a1f3ca37225a1de292e66a2d5aced37a66632585eeb3bbbfa"}}))}`, {
         method: "GET",
         headers: {
-            authorization: `Bearer ${Spicetify.Session.accessToken}`
+            authorization: `Bearer ${Spicetify.Platform.Session.accessToken}`
         }
     })
     .then(res => res.json());


### PR DESCRIPTION
On Spotify Windows version `1.2.38`, Spicetify version `2.36.11`, CoverAmbience is broken when attempting to authenticate with below log from the dev console:
![image](https://github.com/Theblockbuster1/spicetify-extensions/assets/34141617/05fa142f-c870-45b8-a332-ebcee2e8dcf7)

It looks like Spicetify updated their API to a simpler way of fetching the user access token via [`Platform.Session.accessToken`](https://spicetify.app/docs/development/api-wrapper/methods/platform/#accesstoken).

Before:
![image](https://github.com/Theblockbuster1/spicetify-extensions/assets/34141617/f55c7ef2-2fff-487b-a618-31a90b749c4f)
After:
![image](https://github.com/Theblockbuster1/spicetify-extensions/assets/34141617/2983c376-037b-48d3-a333-bba886350e78)
