### PR TITLE
Fix CoverAmbience.js

### DIFF
--- a/CoverAmbience/CoverAmbience.js
+++ b/CoverAmbience/CoverAmbience.js
@@ -163,7 +163,7 @@ function initiate() {
     localStorage.CoverAmbienceBorderOpacity = value / 100;
   }
 
-  const info = document.querySelector("div.main-nowPlayingWidget-trackInfo.main-trackInfo-container");
+  const info = document.querySelector("div.main-trackInfo-container");
 
   var contextMenu = 0;
 


### PR DESCRIPTION
Looks like class names were changed, because no `.main-nowPlayingWidget-trackInfo` class exists anywhere on my Spotify, causing the extension to crash. This PR fixes that.